### PR TITLE
adjust live template values for better typing flow

### DIFF
--- a/src/main/resources/liveTemplates/jte.xml
+++ b/src/main/resources/liveTemplates/jte.xml
@@ -3,21 +3,29 @@
         <context><option name="jte" value="true"/></context>
         <variable name="IMPORT" alwaysStopAt="true" expression="complete()" />
     </template>
+
     <template name="@param" value="@param $TYPE$ $ID$" description="jte param" toReformat="false" toShortenFQNames="false">
         <context><option name="jte" value="true"/></context>
         <variable name="TYPE" alwaysStopAt="true" expression="complete()" />
         <variable name="ID" alwaysStopAt="true" expression="suggestVariableName()" />
     </template>
-    <template name="@if" value="@if($END$)&#10;@endif" description="jte if statement" toReformat="false" toShortenFQNames="false">
+
+    <template name="@if" value="@if($CONDITION$)&#10;    $END$&#10;@endif" description="jte if statement" toReformat="false" toShortenFQNames="false">
+        <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true" />
         <context><option name="jte" value="true"/></context>
     </template>
-    <template name="@elseif" value="@elseif($END$)" description="jte elseif statement" toReformat="false" toShortenFQNames="false">
+
+    <template name="@elseif" value="@elseif($CONDITION$)&#10;    $END$" description="jte elseif statement" toReformat="false" toShortenFQNames="false">
+        <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true" />
         <context><option name="jte" value="true"/></context>
     </template>
-    <template name="@else" value="@else$END$" description="jte else statement" toReformat="false" toShortenFQNames="false">
+
+    <template name="@else" value="@else&#10;    $END$" description="jte else statement" toReformat="false" toShortenFQNames="false">
         <context><option name="jte" value="true"/></context>
     </template>
-    <template name="@for" value="@for($END$)&#10;&#10;@endfor" description="jte for statement" toReformat="true" toShortenFQNames="false">
+
+    <template name="@for" value="@for($CONDITION$)&#10;    $END$&#10;@endfor" description="jte for statement" toReformat="true" toShortenFQNames="false">
+        <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true" />
         <context><option name="jte" value="true"/></context>
     </template>
 


### PR DESCRIPTION
I've been using JTE for a demo project and found it very useful (will be writing a blog post about it soon). I did find some small issues with regards to typing flow for the IntelliJ live templates and have adjusted these here.

For instance when using the `@if` live template, the cursor stops in the space between the brackets of the if condition, so I changed the template value to:

```
if($CONDITION$)
    $END$
endif
```
The same for `@for`, `@else` and `@elseif`. It allows for a more natural typing flow I feel.