### PR TITLE
Add @import optimization and a working "Remove unused @imports" quick fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     // See https://github.com/JetBrains/intellij-platform-gradle-plugin
     intellijPlatform {
-        intellijIdeaCommunity("2024.3.6")
+        intellijIdea("2025.3.6")
 
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.kotlin")
@@ -48,7 +48,7 @@ intellijPlatform {
     }
     pluginVerification {
         ides {
-            create(IntelliJPlatformType.IntellijIdea, "2025.2.5")
+            create(IntelliJPlatformType.IntellijIdea, "2025.3.6")
         }
     }
 }

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
@@ -1,0 +1,94 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
+import com.intellij.ide.util.PsiClassListCellRenderer;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaCodeReferenceElement;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * The generic "Import class" quick fix is unusable for jte's injected Java fragments (it
+ * can crash or silently corrupt the host file), so this edits the host .jte document directly.
+ */
+public class JteAddImportIntention extends PsiElementBaseIntentionAction {
+
+    @Override
+    public @NotNull String getFamilyName() {
+        return "Add @import statement";
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false;
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, @Nullable PsiElement element) {
+        PsiJavaCodeReferenceElement reference = JteImportUtil.findUnresolvedReference(project, element);
+        if (reference == null) {
+            return false;
+        }
+
+        PsiClass[] candidates = JteImportUtil.resolveCandidates(project, reference);
+        if (candidates.length == 0) {
+            return false;
+        }
+
+        if (candidates.length == 1) {
+            setText("Add @import " + candidates[0].getQualifiedName());
+        } else {
+            setText("Add @import for " + reference.getReferenceName());
+        }
+
+        return true;
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, @NotNull PsiElement element) throws IncorrectOperationException {
+        PsiJavaCodeReferenceElement reference = JteImportUtil.findUnresolvedReference(project, element);
+        if (reference == null) {
+            return;
+        }
+
+        PsiClass[] candidates = JteImportUtil.resolveCandidates(project, reference);
+        if (candidates.length == 0) {
+            return;
+        }
+
+        PsiFile injectedFile = reference.getContainingFile();
+
+        if (candidates.length == 1) {
+            addImport(project, injectedFile, candidates[0]);
+            return;
+        }
+
+        Arrays.sort(candidates, Comparator.comparing(PsiClass::getQualifiedName, Comparator.nullsLast(Comparator.naturalOrder())));
+
+        JBPopupFactory.getInstance()
+                .createPopupChooserBuilder(Arrays.asList(candidates))
+                .setRenderer(new PsiClassListCellRenderer())
+                .setTitle("Add Import")
+                .setItemChosenCallback(target -> addImport(project, injectedFile, target))
+                .createPopup()
+                .showInBestPositionFor(editor);
+    }
+
+    private static void addImport(Project project, PsiFile injectedFile, PsiClass target) {
+        String qualifiedName = target.getQualifiedName();
+        if (qualifiedName == null) {
+            return;
+        }
+
+        JteImportUtil.insertImport(project, injectedFile, qualifiedName);
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportClassFixFilter.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportClassFixFilter.java
@@ -1,0 +1,33 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.daemon.impl.IntentionActionFilter;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInsight.intention.IntentionActionDelegate;
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+
+/**
+ * The built-in "Import class" quick fix is broken for jte's injected Java fragments,
+ * and JteAddImportIntention provides a working replacement. Offering both is confusing,
+ * so hide the built-in one for jte-injected references.
+ */
+public class JteImportClassFixFilter implements IntentionActionFilter {
+
+    @Override
+    public boolean accept(@NotNull IntentionAction intentionAction, @Nullable PsiFile file) {
+        if (file == null) {
+            return true;
+        }
+
+        PsiFile topLevelFile = InjectedLanguageManager.getInstance(file.getProject()).getTopLevelFile(file);
+        if (!(topLevelFile instanceof JtePsiFile)) {
+            return true;
+        }
+
+        String className = IntentionActionDelegate.unwrap(intentionAction).getClass().getName();
+        return !className.startsWith("com.intellij.codeInsight.daemon.impl.quickfix.ImportClassFix");
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportOptimizer.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportOptimizer.java
@@ -1,0 +1,24 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.lang.ImportOptimizer;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+
+/**
+ * Removes {@code @import} statements that are no longer referenced from the injected Java
+ * fragments and keeps the remaining imports sorted. Backs the "Optimize Imports" action, the
+ * "Optimize imports" option in the Reformat dialog, and "Optimize imports on the fly".
+ */
+public class JteImportOptimizer implements ImportOptimizer {
+
+    @Override
+    public boolean supports(@NotNull PsiFile file) {
+        return file instanceof JtePsiFile;
+    }
+
+    @Override
+    public @NotNull Runnable processFile(@NotNull PsiFile file) {
+        return () -> JteImportUtil.removeUnusedImports(file);
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
@@ -1,0 +1,80 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.*;
+import com.intellij.psi.search.PsiShortNamesCache;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+
+/**
+ * Shared logic for resolving unresolved references inside jte's injected Java fragments and
+ * adding the corresponding @import statement directly to the host .jte document, bypassing the
+ * broken shortenClassReferences/ImportHelper pipeline.
+ */
+final class JteImportUtil {
+
+    private JteImportUtil() {
+        // no instances
+    }
+
+    @Nullable
+    static PsiJavaCodeReferenceElement findUnresolvedReference(@NotNull Project project, @Nullable PsiElement element) {
+        if (element == null) {
+            return null;
+        }
+
+        PsiFile file = element.getContainingFile();
+        if (file == null) {
+            return null;
+        }
+
+        InjectedLanguageManager injectedLanguageManager = InjectedLanguageManager.getInstance(project);
+        if (!injectedLanguageManager.isInjectedFragment(file)) {
+            return null;
+        }
+
+        if (!(injectedLanguageManager.getTopLevelFile(file) instanceof JtePsiFile)) {
+            return null;
+        }
+
+        PsiJavaCodeReferenceElement reference = PsiTreeUtil.getParentOfType(element, PsiJavaCodeReferenceElement.class, false);
+        if (reference == null || reference.getQualifier() != null || reference.resolve() != null) {
+            return null;
+        }
+
+        return reference;
+    }
+
+    static PsiClass @NotNull [] resolveCandidates(@NotNull Project project, @NotNull PsiJavaCodeReferenceElement reference) {
+        String referenceName = reference.getReferenceName();
+        if (referenceName == null) {
+            return PsiClass.EMPTY_ARRAY;
+        }
+
+        return PsiShortNamesCache.getInstance(project).getClassesByName(referenceName, reference.getResolveScope());
+    }
+
+    static void insertImport(@NotNull Project project, @NotNull PsiFile injectedFile, @NotNull String qualifiedName) {
+        PsiFile jteFile = InjectedLanguageManager.getInstance(project).getTopLevelFile(injectedFile);
+        if (jteFile == null) {
+            return;
+        }
+
+        Document document = PsiDocumentManager.getInstance(project).getDocument(jteFile);
+        if (document == null) {
+            return;
+        }
+
+        String importStatement = "@import " + qualifiedName + "\n";
+
+        WriteCommandAction.runWriteCommandAction(project, "Add Import", null, () -> {
+            document.insertString(0, importStatement);
+            PsiDocumentManager.getInstance(project).commitDocument(document);
+        }, jteFile);
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
@@ -180,6 +180,23 @@ final class JteImportUtil {
         return importText.substring(IMPORT_KEYWORD.length()).trim();
     }
 
+    /**
+     * Returns whether the given {@code @import} statement names the same class as another
+     * {@code @import} statement in the same file, making it redundant regardless of whether the
+     * class is referenced.
+     */
+    static boolean hasDuplicateImport(@NotNull JtePsiImport importElement) {
+        String qualifiedName = extractQualifiedName(importElement.getText());
+
+        int count = 0;
+        for (JtePsiImport existingImport : PsiTreeUtil.findChildrenOfType(importElement.getContainingFile(), JtePsiImport.class)) {
+            if (extractQualifiedName(existingImport.getText()).equals(qualifiedName) && ++count > 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static int skipLineBreaks(@NotNull Document document, int offset) {
         CharSequence text = document.getCharsSequence();
         while (offset < text.length() && (text.charAt(offset) == '\n' || text.charAt(offset) == '\r')) {

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
@@ -16,6 +16,7 @@ import org.jusecase.jte.intellij.language.psi.JtePsiParam;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Shared logic for resolving unresolved references inside jte's injected Java fragments and
@@ -80,33 +81,83 @@ final class JteImportUtil {
         }
 
         WriteCommandAction.runWriteCommandAction(project, "Add Import", null, () -> {
-            insertImportSorted(jteFile, document, qualifiedName);
+            TreeSet<String> names = collectImportNames(jteFile);
+            names.add(qualifiedName);
+            rewriteImports(jteFile, document, names);
             PsiDocumentManager.getInstance(project).commitDocument(document);
         }, jteFile);
     }
 
     /**
-     * Rewrites the leading block of {@code @import} statements in sorted order, including the
-     * new import, and ensures a blank line separates it from a following {@code @param} block.
+     * Removes {@code @import} statements that are no longer referenced from any injected Java
+     * fragment, keeping the remaining imports sorted. Wildcard and static imports are kept as-is
+     * since usage cannot be determined reliably.
      */
-    private static void insertImportSorted(@NotNull PsiFile jteFile, @NotNull Document document, @NotNull String qualifiedName) {
+    static void removeUnusedImports(@NotNull PsiFile jteFile) {
+        Project project = jteFile.getProject();
+        Document document = PsiDocumentManager.getInstance(project).getDocument(jteFile);
+        if (document == null) {
+            return;
+        }
+
+        TreeSet<String> names = collectImportNames(jteFile);
+        names.removeIf(name -> !isImportUsed(jteFile, name));
+
+        if (rewriteImports(jteFile, document, names)) {
+            PsiDocumentManager.getInstance(project).commitDocument(document);
+        }
+    }
+
+    private static TreeSet<String> collectImportNames(@NotNull PsiFile jteFile) {
+        TreeSet<String> names = new TreeSet<>();
+        for (JtePsiImport existingImport : PsiTreeUtil.findChildrenOfType(jteFile, JtePsiImport.class)) {
+            names.add(extractQualifiedName(existingImport.getText()));
+        }
+        return names;
+    }
+
+    static boolean isImportUsed(@NotNull PsiFile jteFile, @NotNull String importedName) {
+        if (importedName.startsWith("static ") || importedName.endsWith(".*")) {
+            return true;
+        }
+
+        String simpleName = importedName.substring(importedName.lastIndexOf('.') + 1);
+        InjectedLanguageManager injectedLanguageManager = InjectedLanguageManager.getInstance(jteFile.getProject());
+
+        AtomicBoolean used = new AtomicBoolean(false);
+        for (PsiLanguageInjectionHost host : PsiTreeUtil.findChildrenOfType(jteFile, PsiLanguageInjectionHost.class)) {
+            injectedLanguageManager.enumerate(host, (injectedPsi, places) -> {
+                if (PsiTreeUtil.findChildrenOfType(injectedPsi, PsiJavaCodeReferenceElement.class).stream()
+                        .anyMatch(ref -> ref.getQualifier() == null && simpleName.equals(ref.getReferenceName()))) {
+                    used.set(true);
+                }
+            });
+
+            if (used.get()) {
+                break;
+            }
+        }
+
+        return used.get();
+    }
+
+    /**
+     * Rewrites the leading block of {@code @import} statements to match the given (sorted) set of
+     * names, ensuring a blank line separates it from a following {@code @param} block. Returns
+     * whether the document was changed.
+     */
+    private static boolean rewriteImports(@NotNull PsiFile jteFile, @NotNull Document document, @NotNull TreeSet<String> names) {
         List<JtePsiImport> imports = PsiTreeUtil.findChildrenOfType(jteFile, JtePsiImport.class).stream()
                 .sorted(Comparator.comparingInt(element -> element.getTextRange().getStartOffset()))
                 .toList();
 
-        TreeSet<String> sortedNames = new TreeSet<>();
-        for (JtePsiImport existingImport : imports) {
-            sortedNames.add(extractQualifiedName(existingImport.getText()));
-        }
-        sortedNames.add(qualifiedName);
-
         boolean hasParams = PsiTreeUtil.findChildOfType(jteFile, JtePsiParam.class) != null;
 
         StringBuilder replacement = new StringBuilder();
-        for (String name : sortedNames) {
+        for (String name : names) {
             replacement.append(IMPORT_PREFIX).append(name).append('\n');
         }
-        if (hasParams) {
+        if (hasParams && !names.isEmpty()) {
             replacement.append('\n');
         }
 
@@ -117,10 +168,15 @@ final class JteImportUtil {
             endOffset = skipLineBreaks(document, imports.getLast().getTextRange().getEndOffset());
         }
 
+        if (document.getCharsSequence().subSequence(startOffset, endOffset).toString().equals(replacement.toString())) {
+            return false;
+        }
+
         document.replaceString(startOffset, endOffset, replacement);
+        return true;
     }
 
-    private static String extractQualifiedName(@NotNull String importText) {
+    static String extractQualifiedName(@NotNull String importText) {
         return importText.substring(IMPORT_KEYWORD.length()).trim();
     }
 

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteImportUtil.java
@@ -10,6 +10,12 @@ import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+import org.jusecase.jte.intellij.language.psi.JtePsiImport;
+import org.jusecase.jte.intellij.language.psi.JtePsiParam;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
 
 /**
  * Shared logic for resolving unresolved references inside jte's injected Java fragments and
@@ -17,6 +23,9 @@ import org.jusecase.jte.intellij.language.psi.JtePsiFile;
  * broken shortenClassReferences/ImportHelper pipeline.
  */
 final class JteImportUtil {
+
+    private static final String IMPORT_KEYWORD = "@import";
+    private static final String IMPORT_PREFIX = IMPORT_KEYWORD + " ";
 
     private JteImportUtil() {
         // no instances
@@ -70,11 +79,56 @@ final class JteImportUtil {
             return;
         }
 
-        String importStatement = "@import " + qualifiedName + "\n";
-
         WriteCommandAction.runWriteCommandAction(project, "Add Import", null, () -> {
-            document.insertString(0, importStatement);
+            insertImportSorted(jteFile, document, qualifiedName);
             PsiDocumentManager.getInstance(project).commitDocument(document);
         }, jteFile);
+    }
+
+    /**
+     * Rewrites the leading block of {@code @import} statements in sorted order, including the
+     * new import, and ensures a blank line separates it from a following {@code @param} block.
+     */
+    private static void insertImportSorted(@NotNull PsiFile jteFile, @NotNull Document document, @NotNull String qualifiedName) {
+        List<JtePsiImport> imports = PsiTreeUtil.findChildrenOfType(jteFile, JtePsiImport.class).stream()
+                .sorted(Comparator.comparingInt(element -> element.getTextRange().getStartOffset()))
+                .toList();
+
+        TreeSet<String> sortedNames = new TreeSet<>();
+        for (JtePsiImport existingImport : imports) {
+            sortedNames.add(extractQualifiedName(existingImport.getText()));
+        }
+        sortedNames.add(qualifiedName);
+
+        boolean hasParams = PsiTreeUtil.findChildOfType(jteFile, JtePsiParam.class) != null;
+
+        StringBuilder replacement = new StringBuilder();
+        for (String name : sortedNames) {
+            replacement.append(IMPORT_PREFIX).append(name).append('\n');
+        }
+        if (hasParams) {
+            replacement.append('\n');
+        }
+
+        int startOffset = 0;
+        int endOffset = 0;
+        if (!imports.isEmpty()) {
+            startOffset = imports.getFirst().getTextRange().getStartOffset();
+            endOffset = skipLineBreaks(document, imports.getLast().getTextRange().getEndOffset());
+        }
+
+        document.replaceString(startOffset, endOffset, replacement);
+    }
+
+    private static String extractQualifiedName(@NotNull String importText) {
+        return importText.substring(IMPORT_KEYWORD.length()).trim();
+    }
+
+    private static int skipLineBreaks(@NotNull Document document, int offset) {
+        CharSequence text = document.getCharsSequence();
+        while (offset < text.length() && (text.charAt(offset) == '\n' || text.charAt(offset) == '\r')) {
+            offset++;
+        }
+        return offset;
     }
 }

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteReferenceImporter.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteReferenceImporter.java
@@ -1,0 +1,64 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.CodeInsightSettings;
+import com.intellij.codeInsight.daemon.ReferenceImporter;
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaCodeReferenceElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Implements IntelliJ's "Add unambiguous imports on the fly" for jte's injected Java fragments,
+ * using the same host-document insertion as JteAddImportIntention.
+ */
+public class JteReferenceImporter implements ReferenceImporter {
+
+    @Override
+    public boolean isAddUnambiguousImportsOnTheFlyEnabled(@NotNull PsiFile file) {
+        if (!(file instanceof JtePsiFile)) {
+            return false;
+        }
+
+        return CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY;
+    }
+
+    @Override
+    public @Nullable BooleanSupplier computeAutoImportAtOffset(@NotNull Editor editor, @NotNull PsiFile file, int offset, boolean allowCaretNearReference) {
+        if (!(file instanceof JtePsiFile)) {
+            return null;
+        }
+
+        Project project = file.getProject();
+        PsiElement injectedElement = InjectedLanguageManager.getInstance(project).findInjectedElementAt(file, offset);
+
+        PsiJavaCodeReferenceElement reference = JteImportUtil.findUnresolvedReference(project, injectedElement);
+        if (reference == null) {
+            return null;
+        }
+
+        PsiClass[] candidates = JteImportUtil.resolveCandidates(project, reference);
+        if (candidates.length != 1) {
+            return null;
+        }
+
+        String qualifiedName = candidates[0].getQualifiedName();
+        if (qualifiedName == null) {
+            return null;
+        }
+
+        PsiFile injectedFile = reference.getContainingFile();
+
+        return () -> {
+            JteImportUtil.insertImport(project, injectedFile, qualifiedName);
+            return true;
+        };
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntention.java
@@ -1,0 +1,69 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+import org.jusecase.jte.intellij.language.psi.JtePsiImport;
+
+/**
+ * Offers to remove all unused {@code @import} statements when the one under the caret is no
+ * longer referenced from any injected Java fragment, mirroring Java's "Remove unused imports"
+ * quick fix.
+ */
+public class JteRemoveUnusedImportIntention extends PsiElementBaseIntentionAction {
+
+    @Override
+    public @NotNull String getFamilyName() {
+        return "Remove unused @imports";
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false;
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, @Nullable PsiElement element) {
+        JtePsiImport unusedImport = findUnusedImport(element);
+        if (unusedImport == null) {
+            return false;
+        }
+
+        setText(getFamilyName());
+        return true;
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, @NotNull PsiElement element) throws IncorrectOperationException {
+        JtePsiImport unusedImport = findUnusedImport(element);
+        if (unusedImport == null) {
+            return;
+        }
+
+        PsiFile jteFile = unusedImport.getContainingFile();
+        WriteCommandAction.runWriteCommandAction(project, "Remove Unused Imports", null, () -> JteImportUtil.removeUnusedImports(jteFile), jteFile);
+    }
+
+    @Nullable
+    private static JtePsiImport findUnusedImport(@Nullable PsiElement element) {
+        if (element == null || !(element.getContainingFile() instanceof JtePsiFile jteFile)) {
+            return null;
+        }
+
+        JtePsiImport possibleImport = PsiTreeUtil.getParentOfType(element, JtePsiImport.class, false);
+        if (possibleImport == null) {
+            return null;
+        }
+
+        String qualifiedName = JteImportUtil.extractQualifiedName(possibleImport.getText());
+        return JteImportUtil.isImportUsed(jteFile, qualifiedName) ? null : possibleImport;
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntention.java
@@ -64,6 +64,7 @@ public class JteRemoveUnusedImportIntention extends PsiElementBaseIntentionActio
         }
 
         String qualifiedName = JteImportUtil.extractQualifiedName(possibleImport.getText());
-        return JteImportUtil.isImportUsed(jteFile, qualifiedName) ? null : possibleImport;
+        boolean unused = !JteImportUtil.isImportUsed(jteFile, qualifiedName) || JteImportUtil.hasDuplicateImport(possibleImport);
+        return unused ? possibleImport : null;
     }
 }

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntention.java
@@ -32,7 +32,7 @@ public class JteRemoveUnusedImportIntention extends PsiElementBaseIntentionActio
 
     @Override
     public boolean isAvailable(@NotNull Project project, Editor editor, @Nullable PsiElement element) {
-        JtePsiImport unusedImport = findUnusedImport(element);
+        JtePsiImport unusedImport = findUnusedImport(editor, element);
         if (unusedImport == null) {
             return false;
         }
@@ -43,7 +43,7 @@ public class JteRemoveUnusedImportIntention extends PsiElementBaseIntentionActio
 
     @Override
     public void invoke(@NotNull Project project, Editor editor, @NotNull PsiElement element) throws IncorrectOperationException {
-        JtePsiImport unusedImport = findUnusedImport(element);
+        JtePsiImport unusedImport = findUnusedImport(editor, element);
         if (unusedImport == null) {
             return;
         }
@@ -53,12 +53,20 @@ public class JteRemoveUnusedImportIntention extends PsiElementBaseIntentionActio
     }
 
     @Nullable
-    private static JtePsiImport findUnusedImport(@Nullable PsiElement element) {
+    private static JtePsiImport findUnusedImport(@NotNull Editor editor, @Nullable PsiElement element) {
         if (element == null || !(element.getContainingFile() instanceof JtePsiFile jteFile)) {
             return null;
         }
 
         JtePsiImport possibleImport = PsiTreeUtil.getParentOfType(element, JtePsiImport.class, false);
+        if (possibleImport == null) {
+            // The @import element's range ends right after the imported class name, so a caret
+            // placed at the end of the line resolves to the following whitespace/newline element.
+            int offset = editor.getCaretModel().getOffset();
+            if (offset > 0) {
+                possibleImport = PsiTreeUtil.getParentOfType(jteFile.findElementAt(offset - 1), JtePsiImport.class, false);
+            }
+        }
         if (possibleImport == null) {
             return null;
         }

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnusedImportFixFilter.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnusedImportFixFilter.java
@@ -1,0 +1,42 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.daemon.impl.IntentionActionFilter;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInsight.intention.IntentionActionDelegate;
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.lang.impl.modcommand.ModCommandActionWrapper;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+
+/**
+ * Java's built-in "Remove unused imports" and "Optimize imports" quick fixes (offered for the
+ * "unused import"/"imports are not sorted" warnings) operate on the injected Java file and try to
+ * modify the guarded {@code "import "}/{@code ";"} text that jte adds around each {@code @import},
+ * which either does nothing or crashes. {@link JteRemoveUnusedImportIntention} and
+ * {@link JteImportOptimizer} already provide working replacements, so hide the built-in ones for
+ * jte-injected files.
+ */
+public class JteUnusedImportFixFilter implements IntentionActionFilter {
+
+    @Override
+    public boolean accept(@NotNull IntentionAction intentionAction, @Nullable PsiFile file) {
+        if (file == null) {
+            return true;
+        }
+
+        PsiFile topLevelFile = InjectedLanguageManager.getInstance(file.getProject()).getTopLevelFile(file);
+        if (!(topLevelFile instanceof JtePsiFile)) {
+            return true;
+        }
+
+        IntentionAction delegate = IntentionActionDelegate.unwrap(intentionAction);
+        String className = delegate instanceof ModCommandActionWrapper wrapper
+                ? wrapper.asModCommandAction().getClass().getName()
+                : delegate.getClass().getName();
+
+        return !className.startsWith("com.intellij.codeInsight.daemon.impl.analysis.RemoveAllUnusedImportsFix")
+                && !className.startsWith("com.intellij.codeInsight.intention.impl.config.QuickFixFactoryImpl$OptimizeImportsFix");
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/refactoring/JteMoveFileHandler.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/refactoring/JteMoveFileHandler.java
@@ -21,6 +21,7 @@ import com.intellij.usageView.UsageInfo;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.jusecase.jte.intellij.language.parsing.JteTokenTypes;
 import org.jusecase.jte.intellij.language.psi.*;
 
@@ -44,7 +45,7 @@ public class JteMoveFileHandler extends MoveFileHandler {
     }
 
     @Override
-    public @Nullable List<UsageInfo> findUsages(PsiFile psiFile, PsiDirectory newParent, boolean searchInComments, boolean searchInNonJavaFiles) {
+    public @Nullable List<UsageInfo> findUsages(@NotNull PsiFile psiFile, @NotNull PsiDirectory newParent, boolean searchInComments, boolean searchInNonJavaFiles) {
         List<UsageInfo> result = new ArrayList<>();
 
         Set<PsiReference> foundReferences = new HashSet<>();
@@ -62,7 +63,7 @@ public class JteMoveFileHandler extends MoveFileHandler {
     }
 
     @Override
-    public void retargetUsages(List<UsageInfo> usageInfos, Map<PsiElement, PsiElement> oldToNewMap) {
+    public void retargetUsages(@Unmodifiable @NotNull List<? extends UsageInfo> usageInfos, @NotNull Map<PsiElement, PsiElement> oldToNewMap) {
         for (UsageInfo usage : usageInfos) {
             if (usage instanceof MoveRenameUsageInfo) {
                 retargetUsage((MoveRenameUsageInfo) usage);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -223,6 +223,15 @@ Support for <a href="https://github.com/casid/jte">jte</a> templates.
         <completion.contributor language="JAVA"
                                 implementationClass="org.jusecase.jte.intellij.language.completion.JteCompletionContributorForJava"/>
 
+        <intentionAction>
+            <language>JAVA</language>
+            <className>org.jusecase.jte.intellij.language.completion.JteAddImportIntention</className>
+            <category>jte</category>
+        </intentionAction>
+
+        <referenceImporter implementation="org.jusecase.jte.intellij.language.completion.JteReferenceImporter"/>
+        <daemon.intentionActionFilter implementation="org.jusecase.jte.intellij.language.completion.JteImportClassFixFilter"/>
+
         <lang.findUsagesProvider language="KotlinTemplateEngine"
                                  implementationClass="org.jusecase.jte.intellij.language.refactoring.KteFindUsagesProvider"/>
         <completion.contributor language="KotlinTemplateEngine"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -229,8 +229,16 @@ Support for <a href="https://github.com/casid/jte">jte</a> templates.
             <category>jte</category>
         </intentionAction>
 
+        <intentionAction>
+            <language>JavaTemplateEngine</language>
+            <className>org.jusecase.jte.intellij.language.completion.JteRemoveUnusedImportIntention</className>
+            <category>jte</category>
+        </intentionAction>
+
         <referenceImporter implementation="org.jusecase.jte.intellij.language.completion.JteReferenceImporter"/>
         <daemon.intentionActionFilter implementation="org.jusecase.jte.intellij.language.completion.JteImportClassFixFilter"/>
+        <daemon.intentionActionFilter implementation="org.jusecase.jte.intellij.language.completion.JteUnusedImportFixFilter"/>
+        <lang.importOptimizer language="JavaTemplateEngine" implementationClass="org.jusecase.jte.intellij.language.completion.JteImportOptimizer"/>
 
         <lang.findUsagesProvider language="KotlinTemplateEngine"
                                  implementationClass="org.jusecase.jte.intellij.language.refactoring.KteFindUsagesProvider"/>

--- a/src/main/resources/intentionDescriptions/JteAddImportIntention/after.jte.template
+++ b/src/main/resources/intentionDescriptions/JteAddImportIntention/after.jte.template
@@ -1,0 +1,4 @@
+@import java.util.HashMap
+
+@param String name
+${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}

--- a/src/main/resources/intentionDescriptions/JteAddImportIntention/before.jte.template
+++ b/src/main/resources/intentionDescriptions/JteAddImportIntention/before.jte.template
@@ -1,0 +1,2 @@
+@param String name
+${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <spot>HashMap</spot>.class.getName().length()}

--- a/src/main/resources/intentionDescriptions/JteAddImportIntention/description.html
+++ b/src/main/resources/intentionDescriptions/JteAddImportIntention/description.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<p>Adds an <code>@import</code> statement to the jte template for a class referenced in an
+injected Java fragment that cannot be resolved yet.</p>
+<p>The existing <code>@import</code> statements at the top of the file are kept sorted
+alphabetically, with the new import merged into place. If the imports are followed by
+<code>@param</code> declarations, a blank line separates the two blocks. If multiple classes
+match the unresolved name, a popup lets you choose which one to import.</p>
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/JteRemoveUnusedImportIntention/after.jte.template
+++ b/src/main/resources/intentionDescriptions/JteRemoveUnusedImportIntention/after.jte.template
@@ -1,0 +1,2 @@
+@param String name
+${name}

--- a/src/main/resources/intentionDescriptions/JteRemoveUnusedImportIntention/before.jte.template
+++ b/src/main/resources/intentionDescriptions/JteRemoveUnusedImportIntention/before.jte.template
@@ -1,0 +1,3 @@
+@import <spot>java.util.HashMap</spot>
+@param String name
+${name}

--- a/src/main/resources/intentionDescriptions/JteRemoveUnusedImportIntention/description.html
+++ b/src/main/resources/intentionDescriptions/JteRemoveUnusedImportIntention/description.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+<p>Removes all unused <code>@import</code> statements, available when the import under the caret
+is not referenced from any injected Java fragment, mirroring the "Optimize Imports" action.</p>
+</body>
+</html>

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntentionTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntentionTest.java
@@ -1,0 +1,49 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+public class JteAddImportIntentionTest extends LightJavaCodeInsightFixtureTestCase {
+
+    @Override
+    protected @NotNull LightProjectDescriptor getProjectDescriptor() {
+        return JAVA_21;
+    }
+
+    public void testAddsImportWhenNoneExist() {
+        myFixture.configureByText("test.jte", "@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>HashMap.class.getName().length()}");
+
+        IntentionAction action = myFixture.findSingleIntention("Add @import java.util.HashMap");
+        myFixture.launchAction(action);
+
+        myFixture.checkResult("@import java.util.HashMap\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+    }
+
+    public void testAddsImportWhenOtherImportExists() {
+        myFixture.configureByText("test.jte", "@import java.util.List\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>HashMap.class.getName().length()}");
+
+        IntentionAction action = myFixture.findSingleIntention("Add @import java.util.HashMap");
+        myFixture.launchAction(action);
+
+        myFixture.checkResult("@import java.util.HashMap\n@import java.util.List\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+    }
+
+    public void testNotAvailableForResolvedReference() {
+        myFixture.configureByText("test.jte", "@import java.util.HashMap\n@param String name\n${new <caret>HashMap<String, String>().size()}");
+
+        assertNull(myFixture.getAvailableIntention("Add @import java.util.HashMap"));
+    }
+
+    public void testAvailableForAmbiguousName() {
+        myFixture.addClass("package a; public class Foo {}");
+        myFixture.addClass("package b; public class Foo {}");
+
+        myFixture.configureByText("test.jte", "@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>Foo.class.getName().length()}");
+
+        assertNull(myFixture.getAvailableIntention("Add @import a.Foo"));
+        assertNull(myFixture.getAvailableIntention("Add @import b.Foo"));
+        assertNotNull(myFixture.getAvailableIntention("Add @import for Foo"));
+    }
+}

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntentionTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntentionTest.java
@@ -18,7 +18,7 @@ public class JteAddImportIntentionTest extends LightJavaCodeInsightFixtureTestCa
         IntentionAction action = myFixture.findSingleIntention("Add @import java.util.HashMap");
         myFixture.launchAction(action);
 
-        myFixture.checkResult("@import java.util.HashMap\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+        myFixture.checkResult("@import java.util.HashMap\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
     }
 
     public void testAddsImportWhenOtherImportExists() {
@@ -27,7 +27,43 @@ public class JteAddImportIntentionTest extends LightJavaCodeInsightFixtureTestCa
         IntentionAction action = myFixture.findSingleIntention("Add @import java.util.HashMap");
         myFixture.launchAction(action);
 
-        myFixture.checkResult("@import java.util.HashMap\n@import java.util.List\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+        myFixture.checkResult("@import java.util.HashMap\n@import java.util.List\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+    }
+
+    public void testInsertsImportAlphabeticallyBetweenExistingImports() {
+        myFixture.configureByText("test.jte", "@import java.util.ArrayList\n@import java.util.List\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>HashMap.class.getName().length()}");
+
+        IntentionAction action = myFixture.findSingleIntention("Add @import java.util.HashMap");
+        myFixture.launchAction(action);
+
+        myFixture.checkResult("@import java.util.ArrayList\n@import java.util.HashMap\n@import java.util.List\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+    }
+
+    public void testInsertsImportAfterExistingImportsWhenItSortsLast() {
+        myFixture.configureByText("test.jte", "@import java.util.ArrayList\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>TreeMap.class.getName().length()}");
+
+        IntentionAction action = myFixture.findSingleIntention("Add @import java.util.TreeMap");
+        myFixture.launchAction(action);
+
+        myFixture.checkResult("@import java.util.ArrayList\n@import java.util.TreeMap\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + TreeMap.class.getName().length()}");
+    }
+
+    public void testSortsExistingUnsortedImports() {
+        myFixture.configureByText("test.jte", "@import java.util.List\n@import java.util.ArrayList\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>HashMap.class.getName().length()}");
+
+        IntentionAction action = myFixture.findSingleIntention("Add @import java.util.HashMap");
+        myFixture.launchAction(action);
+
+        myFixture.checkResult("@import java.util.ArrayList\n@import java.util.HashMap\n@import java.util.List\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+    }
+
+    public void testKeepsExistingBlankLineBeforeParamsSingle() {
+        myFixture.configureByText("test.jte", "@import java.util.List\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>HashMap.class.getName().length()}");
+
+        IntentionAction action = myFixture.findSingleIntention("Add @import java.util.HashMap");
+        myFixture.launchAction(action);
+
+        myFixture.checkResult("@import java.util.HashMap\n@import java.util.List\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
     }
 
     public void testNotAvailableForResolvedReference() {

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteImportClassFixFilterTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteImportClassFixFilterTest.java
@@ -1,0 +1,26 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+public class JteImportClassFixFilterTest extends LightJavaCodeInsightFixtureTestCase {
+
+    @Override
+    protected @NotNull LightProjectDescriptor getProjectDescriptor() {
+        return JAVA_21;
+    }
+
+    public void testBuiltInImportClassFixIsHiddenForUnresolvedReferenceInJteFile() {
+        myFixture.configureByText("test.jte", "@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + <caret>HashMap.class.getName().length()}");
+
+        assertNotNull(myFixture.getAvailableIntention("Add @import java.util.HashMap"));
+        assertNull(myFixture.getAvailableIntention("Import class"));
+    }
+
+    public void testBuiltInImportClassFixIsStillAvailableForUnresolvedReferenceInJavaFile() {
+        myFixture.configureByText("Test.java", "class Test { void m() { Object o = new <caret>HashMap<String, String>(); } }");
+
+        assertNotNull(myFixture.getAvailableIntention("Import class"));
+    }
+}

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteImportOptimizerTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteImportOptimizerTest.java
@@ -1,0 +1,69 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+public class JteImportOptimizerTest extends LightJavaCodeInsightFixtureTestCase {
+
+    private final JteImportOptimizer optimizer = new JteImportOptimizer();
+
+    @Override
+    protected @NotNull LightProjectDescriptor getProjectDescriptor() {
+        return JAVA_21;
+    }
+
+    public void testSupportsJteFilesOnly() {
+        myFixture.configureByText("test.jte", "@param String name\n${name}");
+        assertTrue(optimizer.supports(myFixture.getFile()));
+
+        myFixture.configureByText("Test.java", "class Test {}");
+        assertFalse(optimizer.supports(myFixture.getFile()));
+    }
+
+    public void testRemovesUnusedImport() {
+        myFixture.configureByText("test.jte", "@import java.util.HashMap\n@param String name\n${name}");
+
+        optimize();
+
+        myFixture.checkResult("@param String name\n${name}");
+    }
+
+    public void testKeepsUsedImportAndRemovesUnusedOne() {
+        myFixture.configureByText("test.jte", "@import java.util.ArrayList\n@import java.util.HashMap\n\n@param String name\n${new HashMap<String, String>().size()}");
+
+        optimize();
+
+        myFixture.checkResult("@import java.util.HashMap\n\n@param String name\n${new HashMap<String, String>().size()}");
+    }
+
+    public void testDoesNotChangeFileWithOnlyUsedImports() {
+        myFixture.configureByText("test.jte", "@import java.util.HashMap\n\n@param String name\n${new HashMap<String, String>().size()}");
+
+        optimize();
+
+        myFixture.checkResult("@import java.util.HashMap\n\n@param String name\n${new HashMap<String, String>().size()}");
+    }
+
+    public void testKeepsWildcardImportEvenIfUnused() {
+        myFixture.configureByText("test.jte", "@import java.util.*\n\n@param String name\n${name}");
+
+        optimize();
+
+        myFixture.checkResult("@import java.util.*\n\n@param String name\n${name}");
+    }
+
+    public void testKeepsStaticImportEvenIfUnused() {
+        myFixture.configureByText("test.jte", "@import static java.util.Map.entry\n\n@param String name\n${name}");
+
+        optimize();
+
+        myFixture.checkResult("@import static java.util.Map.entry\n\n@param String name\n${name}");
+    }
+
+    private void optimize() {
+        Runnable runnable = optimizer.processFile(myFixture.getFile());
+        WriteCommandAction.runWriteCommandAction(getProject(), runnable);
+    }
+}

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteReferenceImporterTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteReferenceImporterTest.java
@@ -41,7 +41,7 @@ public class JteReferenceImporterTest extends LightJavaCodeInsightFixtureTestCas
         assertNotNull(supplier);
         assertTrue(supplier.getAsBoolean());
 
-        myFixture.checkResult("@import java.util.HashMap\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+        myFixture.checkResult("@import java.util.HashMap\n\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
     }
 
     public void testComputeAutoImportReturnsNullForAmbiguousCandidate() {

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteReferenceImporterTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteReferenceImporterTest.java
@@ -1,0 +1,65 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.CodeInsightSettings;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.BooleanSupplier;
+
+public class JteReferenceImporterTest extends LightJavaCodeInsightFixtureTestCase {
+
+    private final JteReferenceImporter importer = new JteReferenceImporter();
+
+    @Override
+    protected @NotNull LightProjectDescriptor getProjectDescriptor() {
+        return JAVA_21;
+    }
+
+    public void testOnTheFlyImportsEnabledOnlyWhenSettingIsOn() {
+        myFixture.configureByText("test.jte", "@param String name\n${name}");
+
+        CodeInsightSettings settings = CodeInsightSettings.getInstance();
+        boolean previous = settings.ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY;
+        try {
+            settings.ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = false;
+            assertFalse(importer.isAddUnambiguousImportsOnTheFlyEnabled(myFixture.getFile()));
+
+            settings.ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = true;
+            assertTrue(importer.isAddUnambiguousImportsOnTheFlyEnabled(myFixture.getFile()));
+        } finally {
+            settings.ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = previous;
+        }
+    }
+
+    public void testComputeAutoImportInsertsImportForSingleCandidate() {
+        myFixture.configureByText("test.jte", "@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+
+        int offset = myFixture.getFile().getText().indexOf("HashMap");
+
+        BooleanSupplier supplier = importer.computeAutoImportAtOffset(myFixture.getEditor(), myFixture.getFile(), offset, true);
+        assertNotNull(supplier);
+        assertTrue(supplier.getAsBoolean());
+
+        myFixture.checkResult("@import java.util.HashMap\n@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + HashMap.class.getName().length()}");
+    }
+
+    public void testComputeAutoImportReturnsNullForAmbiguousCandidate() {
+        myFixture.addClass("package a; public class Foo {}");
+        myFixture.addClass("package b; public class Foo {}");
+
+        myFixture.configureByText("test.jte", "@param String name\n${new java.util.concurrent.atomic.AtomicInteger().incrementAndGet() + Foo.class.getName().length()}");
+
+        int offset = myFixture.getFile().getText().indexOf("Foo");
+
+        assertNull(importer.computeAutoImportAtOffset(myFixture.getEditor(), myFixture.getFile(), offset, true));
+    }
+
+    public void testComputeAutoImportReturnsNullForResolvedReference() {
+        myFixture.configureByText("test.jte", "@import java.util.HashMap\n@param String name\n${new HashMap<String, String>().size()}");
+
+        int offset = myFixture.getFile().getText().indexOf("HashMap", myFixture.getFile().getText().indexOf("new"));
+
+        assertNull(importer.computeAutoImportAtOffset(myFixture.getEditor(), myFixture.getFile(), offset, true));
+    }
+}

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntentionTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntentionTest.java
@@ -32,6 +32,15 @@ public class JteRemoveUnusedImportIntentionTest extends LightJavaCodeInsightFixt
         myFixture.checkResult("@param String name\n${name}");
     }
 
+    public void testRemovesDuplicateImport() {
+        myFixture.configureByText("test.jte", "@import java.util.Date\n@import java.util.D<caret>ate\n\n@param String name\n${new Date()}");
+
+        IntentionAction intention = findIntention();
+        myFixture.launchAction(intention);
+
+        myFixture.checkResult("@import java.util.Date\n\n@param String name\n${new Date()}");
+    }
+
     public void testNotAvailableForUsedImport() {
         myFixture.configureByText("test.jte", "@import java.util.Has<caret>hMap\n\n@param String name\n${new HashMap<String, String>().size()}");
 

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntentionTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntentionTest.java
@@ -32,6 +32,15 @@ public class JteRemoveUnusedImportIntentionTest extends LightJavaCodeInsightFixt
         myFixture.checkResult("@param String name\n${name}");
     }
 
+    public void testRemovesUnusedImportWithCaretAtEndOfLine() {
+        myFixture.configureByText("test.jte", "@import java.util.HashMap<caret>\n@param String name\n${name}");
+
+        IntentionAction intention = findIntention();
+        myFixture.launchAction(intention);
+
+        myFixture.checkResult("@param String name\n${name}");
+    }
+
     public void testRemovesDuplicateImport() {
         myFixture.configureByText("test.jte", "@import java.util.Date\n@import java.util.D<caret>ate\n\n@param String name\n${new Date()}");
 

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntentionTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteRemoveUnusedImportIntentionTest.java
@@ -1,0 +1,57 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class JteRemoveUnusedImportIntentionTest extends LightJavaCodeInsightFixtureTestCase {
+
+    @Override
+    protected @NotNull LightProjectDescriptor getProjectDescriptor() {
+        return JAVA_21;
+    }
+
+    public void testRemovesUnusedImportUnderCaret() {
+        myFixture.configureByText("test.jte", "@import java.util.Has<caret>hMap\n@param String name\n${name}");
+
+        IntentionAction intention = findIntention();
+        myFixture.launchAction(intention);
+
+        myFixture.checkResult("@param String name\n${name}");
+    }
+
+    public void testKeepsUsedImportAndRemovesOthers() {
+        myFixture.configureByText("test.jte", "@import java.util.ArrayList\n@import java.util.Has<caret>hMap\n\n@param String name\n${name}");
+
+        IntentionAction intention = findIntention();
+        myFixture.launchAction(intention);
+
+        myFixture.checkResult("@param String name\n${name}");
+    }
+
+    public void testNotAvailableForUsedImport() {
+        myFixture.configureByText("test.jte", "@import java.util.Has<caret>hMap\n\n@param String name\n${new HashMap<String, String>().size()}");
+
+        assertNull(findIntentionOrNull());
+    }
+
+    public void testNotAvailableOutsideImport() {
+        myFixture.configureByText("test.jte", "@import java.util.HashMap\n@param String na<caret>me\n${name}");
+
+        assertNull(findIntentionOrNull());
+    }
+
+    private IntentionAction findIntention() {
+        IntentionAction intention = findIntentionOrNull();
+        assertNotNull("Expected 'Remove unused @imports' intention to be available", intention);
+        return intention;
+    }
+
+    private IntentionAction findIntentionOrNull() {
+        List<IntentionAction> actions = myFixture.filterAvailableIntentions("Remove unused @imports");
+        return actions.isEmpty() ? null : actions.get(0);
+    }
+}

--- a/src/test/java/org/jusecase/jte/intellij/language/completion/JteUnusedImportFixFilterTest.java
+++ b/src/test/java/org/jusecase/jte/intellij/language/completion/JteUnusedImportFixFilterTest.java
@@ -1,0 +1,30 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.unusedImport.UnusedImportInspection;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class JteUnusedImportFixFilterTest extends LightJavaCodeInsightFixtureTestCase {
+
+    @Override
+    protected @NotNull LightProjectDescriptor getProjectDescriptor() {
+        return JAVA_21;
+    }
+
+    public void testHidesBuiltInRemoveUnusedImportsFix() {
+        myFixture.enableInspections(new UnusedImportInspection());
+        myFixture.configureByText("test.jte", "@import java.util.Has<caret>hMap\n@param String name\n${name}");
+        myFixture.doHighlighting();
+
+        assertNoIntention("Remove unused imports");
+    }
+
+    private void assertNoIntention(String text) {
+        List<IntentionAction> actions = myFixture.filterAvailableIntentions(text);
+        assertTrue("Did not expect to find intention '" + text + "', but found: " + actions, actions.isEmpty());
+    }
+}


### PR DESCRIPTION
Improves handling of jte's `@import` statements, since Java's built-in "Remove unused imports" silently does nothing
  and "Optimize imports" crashes on jte's injected import text.

  - Implements `ImportOptimizer` for `.jte`/`.kte` files so unused `@imports` are removed and the rest kept sorted via
  Ctrl+Alt+O, the Reformat dialog, and "optimize imports on save".
  - Adds a "Remove unused @imports" Alt+Enter quick fix that mirrors Java's own but actually works on jte's injected
  imports.
  - Hides Java's broken built-in "Remove unused imports"/"Optimize imports" fixes for `.jte` files via a new
  `IntentionActionFilter`.
  - The quick fix also collapses duplicate `@imports` for the same class and works when the caret sits at the end of the
  import line.
  - Bumps the bundled IntelliJ Platform to 2025.3.6.