### PR TITLE
Fix internal api usage

### DIFF
--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
@@ -1,5 +1,6 @@
 package org.jusecase.jte.intellij.language.completion;
 
+import com.intellij.codeInsight.intention.HighPriorityAction;
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
 import com.intellij.codeInsight.navigation.PsiTargetNavigator;
 import com.intellij.openapi.editor.Editor;
@@ -19,7 +20,7 @@ import java.util.Arrays;
  * The generic "Import class" quick fix is unusable for jte's injected Java fragments (it
  * can crash or silently corrupt the host file), so this edits the host .jte document directly.
  */
-public class JteAddImportIntention extends PsiElementBaseIntentionAction {
+public class JteAddImportIntention extends PsiElementBaseIntentionAction implements HighPriorityAction {
 
     @Override
     public @NotNull String getFamilyName() {

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
@@ -1,6 +1,5 @@
 package org.jusecase.jte.intellij.language.completion;
 
-import com.intellij.codeInsight.intention.HighPriorityAction;
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
 import com.intellij.codeInsight.navigation.PsiTargetNavigator;
 import com.intellij.openapi.editor.Editor;
@@ -20,7 +19,7 @@ import java.util.Arrays;
  * The generic "Import class" quick fix is unusable for jte's injected Java fragments (it
  * can crash or silently corrupt the host file), so this edits the host .jte document directly.
  */
-public class JteAddImportIntention extends PsiElementBaseIntentionAction implements HighPriorityAction {
+public class JteAddImportIntention extends PsiElementBaseIntentionAction {
 
     @Override
     public @NotNull String getFamilyName() {

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
@@ -4,16 +4,16 @@ import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
 import com.intellij.codeInsight.navigation.PsiTargetNavigator;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
-
-import java.util.Arrays;
-import java.util.Comparator;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiJavaCodeReferenceElement;
+import com.intellij.psi.util.proximity.PsiProximityComparator;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
 
 /**
  * The generic "Import class" quick fix is unusable for jte's injected Java fragments (it
@@ -71,7 +71,7 @@ public class JteAddImportIntention extends PsiElementBaseIntentionAction {
             return;
         }
 
-        Arrays.sort(candidates, Comparator.comparing(PsiClass::getQualifiedName, Comparator.nullsLast(Comparator.naturalOrder())));
+        Arrays.sort(candidates, new PsiProximityComparator(element));
 
         new PsiTargetNavigator<>(candidates)
                 .createPopup(project, "Add Import", target -> {

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteAddImportIntention.java
@@ -1,10 +1,12 @@
 package org.jusecase.jte.intellij.language.completion;
 
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
-import com.intellij.ide.util.PsiClassListCellRenderer;
+import com.intellij.codeInsight.navigation.PsiTargetNavigator;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
+
+import java.util.Arrays;
+import java.util.Comparator;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -12,9 +14,6 @@ import com.intellij.psi.PsiJavaCodeReferenceElement;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Arrays;
-import java.util.Comparator;
 
 /**
  * The generic "Import class" quick fix is unusable for jte's injected Java fragments (it
@@ -74,12 +73,11 @@ public class JteAddImportIntention extends PsiElementBaseIntentionAction {
 
         Arrays.sort(candidates, Comparator.comparing(PsiClass::getQualifiedName, Comparator.nullsLast(Comparator.naturalOrder())));
 
-        JBPopupFactory.getInstance()
-                .createPopupChooserBuilder(Arrays.asList(candidates))
-                .setRenderer(new PsiClassListCellRenderer())
-                .setTitle("Add Import")
-                .setItemChosenCallback(target -> addImport(project, injectedFile, target))
-                .createPopup()
+        new PsiTargetNavigator<>(candidates)
+                .createPopup(project, "Add Import", target -> {
+                    addImport(project, injectedFile, target);
+                    return true;
+                })
                 .showInBestPositionFor(editor);
     }
 

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnresolvedReferenceFixProvider.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnresolvedReferenceFixProvider.java
@@ -22,10 +22,6 @@ public class JteUnresolvedReferenceFixProvider extends UnresolvedReferenceQuickF
             return;
         }
 
-        if (JteImportUtil.resolveCandidates(ref.getProject(), ref).length == 0) {
-            return;
-        }
-
         registrar.register(new JteAddImportIntention());
     }
 

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnresolvedReferenceFixProvider.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnresolvedReferenceFixProvider.java
@@ -1,0 +1,36 @@
+package org.jusecase.jte.intellij.language.completion;
+
+import com.intellij.codeInsight.daemon.QuickFixActionRegistrar;
+import com.intellij.codeInsight.quickfix.UnresolvedReferenceQuickFixProvider;
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaCodeReferenceElement;
+import org.jetbrains.annotations.NotNull;
+import org.jusecase.jte.intellij.language.psi.JtePsiFile;
+
+public class JteUnresolvedReferenceFixProvider extends UnresolvedReferenceQuickFixProvider<PsiJavaCodeReferenceElement> {
+
+    @Override
+    public void registerFixes(@NotNull PsiJavaCodeReferenceElement ref, @NotNull QuickFixActionRegistrar registrar) {
+        PsiFile file = ref.getContainingFile();
+        if (file == null) {
+            return;
+        }
+
+        PsiFile topLevelFile = InjectedLanguageManager.getInstance(ref.getProject()).getTopLevelFile(file);
+        if (!(topLevelFile instanceof JtePsiFile)) {
+            return;
+        }
+
+        if (JteImportUtil.resolveCandidates(ref.getProject(), ref).length == 0) {
+            return;
+        }
+
+        registrar.register(new JteAddImportIntention());
+    }
+
+    @Override
+    public @NotNull Class<PsiJavaCodeReferenceElement> getReferenceClass() {
+        return PsiJavaCodeReferenceElement.class;
+    }
+}

--- a/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnusedImportFixFilter.java
+++ b/src/main/java/org/jusecase/jte/intellij/language/completion/JteUnusedImportFixFilter.java
@@ -2,9 +2,7 @@ package org.jusecase.jte.intellij.language.completion;
 
 import com.intellij.codeInsight.daemon.impl.IntentionActionFilter;
 import com.intellij.codeInsight.intention.IntentionAction;
-import com.intellij.codeInsight.intention.IntentionActionDelegate;
 import com.intellij.lang.injection.InjectedLanguageManager;
-import com.intellij.lang.impl.modcommand.ModCommandActionWrapper;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,12 +29,8 @@ public class JteUnusedImportFixFilter implements IntentionActionFilter {
             return true;
         }
 
-        IntentionAction delegate = IntentionActionDelegate.unwrap(intentionAction);
-        String className = delegate instanceof ModCommandActionWrapper wrapper
-                ? wrapper.asModCommandAction().getClass().getName()
-                : delegate.getClass().getName();
-
-        return !className.startsWith("com.intellij.codeInsight.daemon.impl.analysis.RemoveAllUnusedImportsFix")
-                && !className.startsWith("com.intellij.codeInsight.intention.impl.config.QuickFixFactoryImpl$OptimizeImportsFix");
+        String familyName = intentionAction.getFamilyName();
+        return !familyName.equals("Remove unused imports")
+                && !familyName.equals("Optimize imports");
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -235,6 +235,7 @@ Support for <a href="https://github.com/casid/jte">jte</a> templates.
         <referenceImporter implementation="org.jusecase.jte.intellij.language.completion.JteReferenceImporter"/>
         <daemon.intentionActionFilter implementation="org.jusecase.jte.intellij.language.completion.JteImportClassFixFilter"/>
         <daemon.intentionActionFilter implementation="org.jusecase.jte.intellij.language.completion.JteUnusedImportFixFilter"/>
+        <codeInsight.unresolvedReferenceQuickFixProvider implementation="org.jusecase.jte.intellij.language.completion.JteUnresolvedReferenceFixProvider"/>
         <lang.importOptimizer language="JavaTemplateEngine" implementationClass="org.jusecase.jte.intellij.language.completion.JteImportOptimizer"/>
 
         <defaultLiveTemplates file="liveTemplates/jte.xml"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -221,12 +221,6 @@ Support for <a href="https://github.com/casid/jte">jte</a> templates.
                                 implementationClass="org.jusecase.jte.intellij.language.completion.JteCompletionContributorForJava"/>
 
         <intentionAction>
-            <language>JAVA</language>
-            <className>org.jusecase.jte.intellij.language.completion.JteAddImportIntention</className>
-            <category>jte</category>
-        </intentionAction>
-
-        <intentionAction>
             <language>JavaTemplateEngine</language>
             <className>org.jusecase.jte.intellij.language.completion.JteRemoveUnusedImportIntention</className>
             <category>jte</category>


### PR DESCRIPTION
This also improves ranking of the import options as well as the intention order. Switching to `PsiTargetNavigator`fixes an error triggered by the plugin.